### PR TITLE
make download function work with non-US-ASCII characters

### DIFF
--- a/remi/gui.py
+++ b/remi/gui.py
@@ -44,7 +44,10 @@ except ImportError:
         unescape = html.unescape
 
 from .server import runtimeInstances
-import urllib.parse
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
 
 log = logging.getLogger('remi.gui')
 
@@ -4136,9 +4139,9 @@ class FileDownloader(Container, _MixinTextualWidget):
     def download(self):
         with open(self._filename, 'r+b') as f:
             content = f.read()
-        filename = urllib.parse.quote(os.path.basename(self._filename))
+        filename = quote(os.path.basename(self._filename))
         headers = {'Content-type': 'application/octet-stream',
-                   'Content-Disposition': f'attachment; filename="{filename}"; filename*=UTF-8\'\'{filename}'}
+                   'Content-Disposition': 'attachment; filename="{0}"; filename*=UTF-8\'\'{0}'.format(filename)}
         return [content, headers]
 
 

--- a/remi/gui.py
+++ b/remi/gui.py
@@ -44,7 +44,7 @@ except ImportError:
         unescape = html.unescape
 
 from .server import runtimeInstances
-
+import urllib.parse
 
 log = logging.getLogger('remi.gui')
 
@@ -4136,8 +4136,9 @@ class FileDownloader(Container, _MixinTextualWidget):
     def download(self):
         with open(self._filename, 'r+b') as f:
             content = f.read()
+        filename = urllib.parse.quote(os.path.basename(self._filename))
         headers = {'Content-type': 'application/octet-stream',
-                   'Content-Disposition': 'attachment; filename="%s"' % os.path.basename(self._filename)}
+                   'Content-Disposition': f'attachment; filename="{filename}"; filename*=UTF-8\'\'{filename}'}
         return [content, headers]
 
 


### PR DESCRIPTION
Fixed #441 . After this fix, you'll be able to use "download" function of Remi to download files with non-ASCII characters in the filename.